### PR TITLE
Enable inserting the equations in native Markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ You can specify the path to save the locally rendered SVG image. The settings ar
 * **vscode-math-to-image.remoteRenderEngine**:
   * `GitHub`: Equations will be rendered with GitHub's rendering engine remotely.
   * `CodeCogs`: Equations will be rendered with CodeCogs' rendering engine remotely.
-* **vscode-math-to-image.inlineSvgStyle**: Optional style for rendered inline SVG equations. Defaults to `transform: translateY(0.1em); background: white;`.
-* **vscode-math-to-image.displaySvgStyle**: Optional style for rendered display SVG equations. Defaults to `background: white;`.
+* **vscode-math-to-image.inlineSvgStyle**: Optional style for rendered inline SVG equations. Defaults to `transform: translateY(0.1em); background: white;`. Note: Not supported with Markdown-insertionType.
+* **vscode-math-to-image.displaySvgStyle**: Optional style for rendered display SVG equations. Defaults to `background: white;`. Note: Not supported with Markdown-insertionType.
+* **vscode-math-to-image.insertionType**: Choose whether to insert the rendered equations as HTML (default) or Markdown. Note that Markdown doesn't support styling.
 
 ## Change Log
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
             "Equations will be rendered with CodeCogs' rendering engine remotely."
           ]
         },
-        "vscode-math-to-image.insertType": {
+        "vscode-math-to-image.insertionType": {
           "type": "string",
           "default": "HTML",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -81,15 +81,27 @@
             "Equations will be rendered with CodeCogs' rendering engine remotely."
           ]
         },
+        "vscode-math-to-image.insertType": {
+          "type": "string",
+          "default": "HTML",
+          "enum": [
+            "HTML",
+            "Markdown"
+          ],
+          "enumDescriptions": [
+            "Equations will be inserted as HTML.",
+            "Equations will be inserted as Markdown. Note that this doesn't support styles!"
+          ]
+        },
         "vscode-math-to-image.inlineSvgStyle": {
           "type": "string",
           "default": "transform: translateY(0.1em); background: white;",
-          "description": "Optional style for rendered inline SVG equations."
+          "description": "Optional style for rendered inline SVG equations. (Only supported when inserting as HTML)"
         },
         "vscode-math-to-image.displaySvgStyle": {
           "type": "string",
           "default": "background: white;",
-          "description": "Optional style for rendered display SVG equations."
+          "description": "Optional style for rendered display SVG equations. (Only supported when inserting as HTML)"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ function generateEquationHtml(src: string, mathType: MathType) {
 }
 
 /**
- * Encode URL and return rendered <img> tag based on selected equation
+ * Encode URL and return rendered image path based on selected equation
  *
  * @param equation Selected inline or display equation
  * @param mathType Equation type (inline / display)
@@ -99,7 +99,7 @@ function renderEquationRemote(equation: string, mathType: MathType) {
   }
 
   const encodedMath = encodeURIComponent(equation)
-  return generateEquationHtml(`${renderAPIUrl}${encodedMath}`, mathType)
+  return `${renderAPIUrl}${encodedMath}`
 }
 
 /**
@@ -129,21 +129,38 @@ function renderEquationLocal(equation: string, mathType: MathType) {
       vscode.window.showErrorMessage(`[err]: ${err}`)
     })
 
-  return generateEquationHtml(relativeSvgPath, mathType)
+  return relativeSvgPath
 }
 
 /**
- * Insert rendered image string into current VS Code editor
+ * Insert rendered image into current VS Code editor
  *
- * @param renderedImage Rendered image string (remote or local image)
+ * @param renderedImagePath Path to rendered image (remote or local image)
  * @param start Selection start
  * @param end Selection end
  */
-function insertMathImage(renderedImage: string, start: vscode.Position, end: vscode.Position, mathType: MathType) {
-  editor?.edit(editBuilder => {
-    editBuilder.insert(start, '<!-- ')
-    editBuilder.insert(end, ` --> ${renderedImage}`)
-  })
+function insertMathImage(renderedImagePath: string, start: vscode.Position, end: vscode.Position, mathType: MathType) {
+  const insertType = vscode.workspace.getConfiguration().get("vscode-math-to-image.insertType")
+  if(insertType === 'HTML')
+  {
+    const renderedImageCode = generateEquationHtml(renderedImagePath, mathType)
+    editor?.edit(editBuilder => {
+      editBuilder.insert(start, '<!-- ')
+      editBuilder.insert(end, ` --> ${renderedImageCode}`)
+    })
+  }
+  else if(insertType === 'Markdown')
+  {
+    editor?.edit(editBuilder => {
+      if(mathType === MathType.DISPLAY)
+      {
+        editBuilder.insert(start, '\n\n')
+        start.translate(0,2)
+      }
+      editBuilder.insert(start, '![')
+      editBuilder.insert(end, `](${renderedImagePath})`)
+    })
+  }
   vscode.window.showInformationMessage(`Render equation successfully!`)
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,8 +140,8 @@ function renderEquationLocal(equation: string, mathType: MathType) {
  * @param end Selection end
  */
 function insertMathImage(renderedImagePath: string, start: vscode.Position, end: vscode.Position, mathType: MathType) {
-  const insertType = vscode.workspace.getConfiguration().get("vscode-math-to-image.insertType")
-  if(insertType === 'HTML')
+  const insertionType = vscode.workspace.getConfiguration().get("vscode-math-to-image.insertionType")
+  if(insertionType === 'HTML')
   {
     const renderedImageCode = generateEquationHtml(renderedImagePath, mathType)
     editor?.edit(editBuilder => {
@@ -149,7 +149,7 @@ function insertMathImage(renderedImagePath: string, start: vscode.Position, end:
       editBuilder.insert(end, ` --> ${renderedImageCode}`)
     })
   }
-  else if(insertType === 'Markdown')
+  else if(insertionType === 'Markdown')
   {
     editor?.edit(editBuilder => {
       if(mathType === MathType.DISPLAY)


### PR DESCRIPTION
Hi, as suggested in issue #5, it would be great if the equations could also be inserted as native markdown, in cases where one does not want to use HTML. I implemented this in this PR, please have a look and let me know if I should change anything :)

By default, the extension will still insert HTML, but users can select if they want to have the image inserted as Markdown.

I know that with this, styles can not be used, and I documented that in the setting-descriptions.